### PR TITLE
Implement creative search pipeline skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,104 @@
 # CreativeSearchandRetreival
-Create a pipeline for finding and categorizing trends and 
+
+This repository contains a reference implementation of the plan outlined in the
+shared conversation for building a *Creative Search and Retrieval* pipeline.
+The code base is structured as a small Python package (`creative_search`) that
+orchestrates the following stages:
+
+1. **Ingestion & conversion** – traverse configured server folders, optionally
+   pull new files from DingTalk, and convert supported assets to Markdown using
+   [MarkItDown](https://github.com/microsoft/markitdown) when the library is
+   installed. Plain-text files fall back to direct reading.
+2. **Metadata extraction** – apply lightweight heuristics (and spaCy when
+   available) to identify concepts, colours, materials, product names, prices,
+   and other named entities inside the converted Markdown content.
+3. **Embedding generation** – use `sentence-transformers` to create dense vector
+   representations, or a deterministic hash-based embedding when the library is
+   not available. The abstraction keeps local development lightweight while
+   enabling higher quality vectors in production.
+4. **Vector storage** – push embeddings into a FAISS index when the dependency
+   exists, or into a pure NumPy fallback. Metadata is persisted in SQLite via
+   SQLAlchemy, with an in-memory fallback for minimal environments.
+5. **Retrieval API** – expose a FastAPI service that performs semantic search
+   over the indexed documents and returns rich metadata for each match.
+
+## Repository layout
+
+```
+creative_search/
+├── __init__.py          # Package export convenience
+├── ingestion.py         # File listing, DingTalk placeholder, Markdown conversion
+├── extraction.py        # Heuristics for structured metadata extraction
+├── embedding.py         # SentenceTransformer wrapper with hash fallback
+├── models.py            # SQLAlchemy model definitions and fallbacks
+├── storage.py           # Vector index management and search utilities
+├── pipeline.py          # CLI and orchestration helpers for the ingestion run
+└── main.py              # FastAPI application exposing the search endpoint
+```
+
+## Installation
+
+Create a virtual environment and install the core dependencies:
+
+```sh
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install sqlalchemy numpy
+```
+
+Optional enhancements:
+
+- `pip install markitdown` – enable rich document conversion.
+- `pip install sentence-transformers` – use high-quality text embeddings.
+- `pip install faiss-cpu` – leverage the native FAISS index.
+- `pip install fastapi uvicorn pydantic` – run the HTTP API.
+- `pip install spacy && python -m spacy download en_core_web_sm` – improve
+  entity recognition during extraction.
+
+The code automatically falls back to lighter-weight implementations when these
+packages are absent, which makes local experimentation easy while still keeping
+an upgrade path for production deployments.
+
+## Running the pipeline
+
+The pipeline can be executed via the command line. The example below scans two
+folders for PDF and PowerPoint files and populates the vector index:
+
+```sh
+python -m creative_search.pipeline \
+  --dirs /srv/design-assets /srv/shared/briefs \
+  --extensions pdf pptx docx
+```
+
+Additional options:
+
+- `--ding-token` / `--ding-channel` – (placeholder) configuration for retrieving
+  attachments from DingTalk and dropping them into the first directory.
+- `--database-url` – custom SQLAlchemy URL. Defaults to `sqlite:///metadata.db`.
+
+## Starting the API
+
+After running the ingestion pipeline you can start the FastAPI service:
+
+```sh
+uvicorn creative_search.main:app --host 0.0.0.0 --port 8000
+```
+
+Query the endpoint with `GET /search?query=red+leather+jacket` to receive the
+closest matches (including extracted metadata). A simple health check is
+exposed at `GET /healthz`.
+
+## Development notes
+
+- The storage layer exposes an in-memory fallback when SQLAlchemy is not
+  installed, which is useful for unit tests or rapid prototyping.
+- The hash-based embedding fallback ensures deterministic behaviour without
+  requiring heavyweight ML downloads. Replace it with `sentence-transformers`
+  in production for higher-quality results.
+- DingTalk integration is represented by a stub in `ingestion.py`. Replace the
+  placeholder with real API calls once credentials are available.
+
+## License
+
+MIT

--- a/creative_search/__init__.py
+++ b/creative_search/__init__.py
@@ -1,0 +1,19 @@
+"""Utilities for building a creative document search pipeline.
+
+This package bundles helper modules for ingesting rich-media
+files, extracting structured metadata, generating embeddings,
+and exposing a simple retrieval API. The implementation follows
+the plan outlined in the shared conversation for the
+"Creative Search and Retrieval" prototype.
+"""
+
+from . import ingestion, extraction, embedding, models, storage, pipeline
+
+__all__ = [
+    "ingestion",
+    "extraction",
+    "embedding",
+    "models",
+    "storage",
+    "pipeline",
+]

--- a/creative_search/embedding.py
+++ b/creative_search/embedding.py
@@ -1,0 +1,79 @@
+"""Vector embedding utilities."""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+DEFAULT_MODEL_NAME = "all-MiniLM-L6-v2"
+
+
+@dataclass
+class EmbeddingBackend:
+    """Wrapper that hides the optional SentenceTransformer dependency."""
+
+    model_name: str = DEFAULT_MODEL_NAME
+
+    def __post_init__(self) -> None:
+        try:  # pragma: no cover - optional heavy dependency
+            from sentence_transformers import SentenceTransformer
+
+            self._model = SentenceTransformer(self.model_name)
+            self._dimension = int(self._model.get_sentence_embedding_dimension())
+            self._backend = "sentence-transformers"
+        except Exception:  # pragma: no cover - handle missing library
+            self._model = None
+            self._dimension = 384
+            self._backend = "hashed"
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    @property
+    def backend(self) -> str:
+        return self._backend
+
+    def encode(self, texts: Iterable[str]) -> np.ndarray:
+        if self._model is not None:
+            return np.asarray(
+                self._model.encode(list(texts), show_progress_bar=False), dtype=np.float32
+            )
+        return np.vstack([_hash_to_unit_vector(text, self._dimension) for text in texts])
+
+
+_BACKEND: EmbeddingBackend | None = None
+
+
+def get_backend(model_name: str = DEFAULT_MODEL_NAME) -> EmbeddingBackend:
+    global _BACKEND
+    if _BACKEND is None or _BACKEND.model_name != model_name:
+        _BACKEND = EmbeddingBackend(model_name)
+    return _BACKEND
+
+
+def generate_embedding(text: str) -> np.ndarray:
+    backend = get_backend()
+    return backend.encode([text])[0]
+
+
+def batch_generate_embedding(texts: Iterable[str]) -> np.ndarray:
+    backend = get_backend()
+    return backend.encode(list(texts))
+
+
+def _hash_to_unit_vector(text: str, dimension: int) -> np.ndarray:
+    """Create a deterministic pseudo-embedding when real models are unavailable."""
+
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    # Repeat digest to cover desired dimensionality
+    needed = dimension * 4
+    data = (digest * (needed // len(digest) + 1))[: needed]
+    vector = np.frombuffer(data, dtype=np.uint32).astype(np.float32)
+    vector = vector[:dimension]
+    norm = np.linalg.norm(vector)
+    if norm == 0.0:
+        return np.zeros(dimension, dtype=np.float32)
+    return vector / norm

--- a/creative_search/extraction.py
+++ b/creative_search/extraction.py
@@ -1,0 +1,150 @@
+"""Content extraction heuristics for converted Markdown documents."""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+_COLOR_KEYWORDS = {
+    "red",
+    "blue",
+    "green",
+    "black",
+    "white",
+    "gold",
+    "silver",
+    "beige",
+    "yellow",
+    "purple",
+    "pink",
+    "gray",
+}
+
+_MATERIAL_KEYWORDS = {
+    "cotton",
+    "silk",
+    "leather",
+    "denim",
+    "wool",
+    "linen",
+    "wood",
+    "plastic",
+    "metal",
+    "glass",
+}
+
+_PRODUCT_TYPES = {
+    "dress",
+    "shoe",
+    "bag",
+    "coat",
+    "jacket",
+    "shirt",
+    "pants",
+    "skirt",
+    "scarf",
+    "accessory",
+}
+
+_PRICE_PATTERN = re.compile(r"\$[\d,]+(?:\.\d+)?")
+_WORD_PATTERN = re.compile(r"[A-Za-z][A-Za-z\-']+")
+
+
+@dataclass
+class ExtractionResult:
+    """Structured metadata extracted from a document."""
+
+    concepts: List[str] = field(default_factory=list)
+    colors: List[str] = field(default_factory=list)
+    materials: List[str] = field(default_factory=list)
+    prices: List[str] = field(default_factory=list)
+    product_types: List[str] = field(default_factory=list)
+    clients: List[str] = field(default_factory=list)
+    product_lines: List[str] = field(default_factory=list)
+    proper_nouns: List[str] = field(default_factory=list)
+
+    def asdict(self) -> dict:
+        return {
+            "concepts": self.concepts,
+            "colors": self.colors,
+            "materials": self.materials,
+            "prices": self.prices,
+            "product_types": self.product_types,
+            "clients": self.clients,
+            "product_lines": self.product_lines,
+            "proper_nouns": self.proper_nouns,
+        }
+
+
+def _load_spacy_model():  # pragma: no cover - optional dependency
+    try:
+        import spacy
+
+        return spacy.load("en_core_web_sm")
+    except Exception:
+        return None
+
+
+_NLP = _load_spacy_model()
+
+
+def _extract_proper_nouns(text: str) -> List[str]:
+    if _NLP is None:
+        # Simple fallback: capitalised words that are not sentence starters.
+        tokens = _WORD_PATTERN.findall(text)
+        proper = [tok for tok in tokens if tok[0].isupper() and not tok.isupper()]
+        return sorted(set(proper))
+
+    doc = _NLP(text)
+    return [ent.text for ent in doc.ents if ent.label_ in {"PERSON", "ORG", "GPE", "PRODUCT"}]
+
+
+def _classify_clients_and_products(names: Iterable[str]) -> tuple[List[str], List[str]]:
+    clients: List[str] = []
+    product_lines: List[str] = []
+    for name in names:
+        normalized = name.lower()
+        if any(suffix in normalized for suffix in (" inc", " ltd", " llc", " corporation")):
+            clients.append(name)
+        else:
+            product_lines.append(name)
+    return sorted(set(clients)), sorted(set(product_lines))
+
+
+def extract_entities(markdown_text: str) -> ExtractionResult:
+    """Extract structured metadata from Markdown text."""
+
+    # Remove Markdown syntax for lighter parsing
+    clean_text = re.sub(r"[#>*_`]+", " ", markdown_text)
+
+    prices = _PRICE_PATTERN.findall(clean_text)
+
+    tokens = [token.lower() for token in _WORD_PATTERN.findall(clean_text)]
+    colors = sorted({token for token in tokens if token in _COLOR_KEYWORDS})
+    materials = sorted({token for token in tokens if token in _MATERIAL_KEYWORDS})
+    product_types = sorted({token for token in tokens if token in _PRODUCT_TYPES})
+
+    proper_nouns = _extract_proper_nouns(clean_text)
+    clients, product_lines = _classify_clients_and_products(proper_nouns)
+
+    # Candidate "concepts" are the most common nouns / meaningful tokens.
+    # With spaCy we can use part-of-speech tags; otherwise frequency heuristics.
+    if _NLP is None:
+        counter = Counter(token for token in tokens if len(token) > 3)
+        concepts = [word for word, _ in counter.most_common(15)]
+    else:
+        doc = _NLP(clean_text)
+        counter = Counter(token.lemma_.lower() for token in doc if token.pos_ == "NOUN")
+        concepts = [word for word, _ in counter.most_common(20)]
+
+    return ExtractionResult(
+        concepts=concepts,
+        colors=colors,
+        materials=materials,
+        prices=prices,
+        product_types=product_types,
+        clients=clients,
+        product_lines=product_lines,
+        proper_nouns=sorted(set(proper_nouns)),
+    )

--- a/creative_search/ingestion.py
+++ b/creative_search/ingestion.py
@@ -1,0 +1,112 @@
+"""File ingestion and conversion helpers.
+
+The helper functions in this module deliberately keep their
+interfaces small so they can be orchestrated inside the pipeline
+module or reused in notebooks.  They follow the breakdown
+outlined in the specification shared via the conversation link.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Mapping, Optional, Sequence, Set
+
+try:  # pragma: no cover - optional dependency
+    from markitdown import MarkItDown
+
+    _MARKITDOWN_AVAILABLE = True
+except ImportError:  # pragma: no cover - markitdown is optional
+    MarkItDown = None  # type: ignore
+    _MARKITDOWN_AVAILABLE = False
+
+
+def list_files(
+    base_dirs: Sequence[str | Path],
+    extensions: Optional[Set[str]] = None,
+) -> Iterator[Path]:
+    """Yield files under ``base_dirs`` optionally filtered by ``extensions``.
+
+    Parameters
+    ----------
+    base_dirs:
+        A sequence of root directories to traverse.
+    extensions:
+        Lower-case file extensions to include (e.g. {"pdf", "pptx"}).
+        When ``None`` all files are yielded.
+    """
+
+    normalized_exts = {ext.lower().lstrip(".") for ext in extensions} if extensions else None
+
+    for base in base_dirs:
+        base_path = Path(base).expanduser().resolve()
+        if not base_path.exists():
+            continue
+        for path in base_path.rglob("*"):
+            if not path.is_file():
+                continue
+            if normalized_exts:
+                suffix = path.suffix.lower().lstrip(".")
+                if suffix not in normalized_exts:
+                    continue
+            yield path
+
+
+def convert_file_to_markdown(path: str | Path, *, encoding: str = "utf-8") -> str:
+    """Convert ``path`` to Markdown using MarkItDown when available.
+
+    The real system is expected to support many binary formats via
+    `markitdown`.  For local development the dependency is optional;
+    if it is missing we fall back to returning the raw text for plain
+    text / Markdown documents, which keeps the pipeline usable for
+    smoke tests.
+    """
+
+    source = Path(path)
+    if not source.exists():
+        raise FileNotFoundError(source)
+
+    if _MARKITDOWN_AVAILABLE and MarkItDown is not None:
+        converter = MarkItDown(enable_plugins=False)
+        result = converter.convert(str(source))
+        return result.text_content
+
+    # Fallback for plain-text friendly formats
+    try:
+        return source.read_text(encoding=encoding)
+    except UnicodeDecodeError as exc:  # pragma: no cover - depends on file contents
+        raise RuntimeError(
+            "markitdown is not installed and the file could not be decoded as text"
+        ) from exc
+
+
+def ingest_and_convert(file_paths: Iterable[str | Path]) -> Dict[str, str]:
+    """Convert the given files and return a mapping ``path -> markdown``.
+
+    Conversion errors are logged but do not stop the pipeline, mirroring
+    the fault-tolerant guidance from the original plan.
+    """
+
+    markdown_map: Dict[str, str] = {}
+    for path in file_paths:
+        try:
+            markdown_map[str(path)] = convert_file_to_markdown(path)
+        except Exception as error:  # pragma: no cover - logging path
+            print(f"[ingestion] Failed to convert {path}: {error}")
+    return markdown_map
+
+
+def download_from_dingtalk(
+    token: str,
+    channel_id: str,
+    dest_dir: str | Path,
+) -> Mapping[str, str]:
+    """Placeholder for pulling attachments from DingTalk.
+
+    The plan calls for integrating DingTalk but the concrete API
+    contract depends on an organization's credentials.  This
+    placeholder returns an empty mapping and documents where real
+    integration logic should live.
+    """
+
+    _ = (token, channel_id)  # hint that the parameters are intentionally unused
+    Path(dest_dir).mkdir(parents=True, exist_ok=True)
+    return {}

--- a/creative_search/main.py
+++ b/creative_search/main.py
@@ -1,0 +1,60 @@
+"""FastAPI application exposing semantic search endpoints."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+try:  # pragma: no cover - optional dependency
+    from fastapi import FastAPI, Query
+    from pydantic import BaseModel, Field
+except ImportError as exc:  # pragma: no cover - make the error actionable
+    raise ImportError(
+        "FastAPI and Pydantic are required for the API. Install them via 'pip install fastapi pydantic'."
+    ) from exc
+
+from . import storage
+
+
+class SearchResult(BaseModel):
+    score: float
+    file_path: str
+    file_url: Optional[str] = None
+    concepts: List[str] = Field(default_factory=list)
+    colors: List[str] = Field(default_factory=list)
+    materials: List[str] = Field(default_factory=list)
+    prices: List[str] = Field(default_factory=list)
+    product_types: List[str] = Field(default_factory=list)
+    clients: List[str] = Field(default_factory=list)
+    product_lines: List[str] = Field(default_factory=list)
+    proper_nouns: List[str] = Field(default_factory=list)
+
+
+app = FastAPI(title="Creative Search and Retrieval")
+
+
+@app.get("/healthz")
+def healthcheck() -> dict:
+    return {"status": "ok"}
+
+
+@app.get("/search", response_model=List[SearchResult])
+def search(query: str = Query(..., description="Search phrase"), k: int = Query(5, ge=1, le=50)):
+    results = storage.search_similar(query, k)
+    payload: List[SearchResult] = []
+    for result in results:
+        metadata = result["metadata"]
+        payload.append(
+            SearchResult(
+                score=result["score"],
+                file_path=metadata.get("file_path"),
+                file_url=metadata.get("file_url"),
+                concepts=metadata.get("concepts", []),
+                colors=metadata.get("colors", []),
+                materials=metadata.get("materials", []),
+                prices=metadata.get("prices", []),
+                product_types=metadata.get("product_types", []),
+                clients=metadata.get("clients", []),
+                product_lines=metadata.get("product_lines", []),
+                proper_nouns=metadata.get("proper_nouns", []),
+            )
+        )
+    return payload

--- a/creative_search/models.py
+++ b/creative_search/models.py
@@ -1,0 +1,91 @@
+"""Database models used by the pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+try:  # pragma: no cover - optional dependency
+    from sqlalchemy import JSON, Column, Integer, String, create_engine
+    from sqlalchemy.orm import declarative_base, sessionmaker
+
+    SQLALCHEMY_AVAILABLE = True
+except Exception:  # pragma: no cover - degrade gracefully
+    JSON = Column = Integer = String = create_engine = None  # type: ignore
+    sessionmaker = None  # type: ignore
+    declarative_base = lambda: None  # type: ignore
+    SQLALCHEMY_AVAILABLE = False
+
+
+if SQLALCHEMY_AVAILABLE:
+    Base = declarative_base()
+
+    class DocumentMetadata(Base):
+        __tablename__ = "documents"
+
+        id = Column(Integer, primary_key=True)
+        file_path = Column(String, unique=True, nullable=False)
+        file_url = Column(String, nullable=True)
+        concepts = Column(JSON, nullable=True)
+        colors = Column(JSON, nullable=True)
+        materials = Column(JSON, nullable=True)
+        prices = Column(JSON, nullable=True)
+        product_types = Column(JSON, nullable=True)
+        clients = Column(JSON, nullable=True)
+        product_lines = Column(JSON, nullable=True)
+        proper_nouns = Column(JSON, nullable=True)
+        embedding_index = Column(Integer, nullable=False)
+
+        def as_dict(self) -> dict:
+            return {
+                "file_path": self.file_path,
+                "file_url": self.file_url,
+                "concepts": self.concepts or [],
+                "colors": self.colors or [],
+                "materials": self.materials or [],
+                "prices": self.prices or [],
+                "product_types": self.product_types or [],
+                "clients": self.clients or [],
+                "product_lines": self.product_lines or [],
+                "proper_nouns": self.proper_nouns or [],
+            }
+
+    def create_session_factory(database_url: str = "sqlite:///metadata.db"):
+        engine = create_engine(database_url)
+        Base.metadata.create_all(engine)
+        return sessionmaker(bind=engine)
+
+else:
+    Base = None
+
+    @dataclass
+    class DocumentMetadata:  # pragma: no cover - fallback container
+        file_path: str
+        file_url: str | None = None
+        concepts: Sequence[str] = field(default_factory=list)
+        colors: Sequence[str] = field(default_factory=list)
+        materials: Sequence[str] = field(default_factory=list)
+        prices: Sequence[str] = field(default_factory=list)
+        product_types: Sequence[str] = field(default_factory=list)
+        clients: Sequence[str] = field(default_factory=list)
+        product_lines: Sequence[str] = field(default_factory=list)
+        proper_nouns: Sequence[str] = field(default_factory=list)
+        embedding_index: int = -1
+
+        def as_dict(self) -> dict:
+            return {
+                "file_path": self.file_path,
+                "file_url": self.file_url,
+                "concepts": list(self.concepts),
+                "colors": list(self.colors),
+                "materials": list(self.materials),
+                "prices": list(self.prices),
+                "product_types": list(self.product_types),
+                "clients": list(self.clients),
+                "product_lines": list(self.product_lines),
+                "proper_nouns": list(self.proper_nouns),
+            }
+
+    def create_session_factory(database_url: str = "sqlite:///metadata.db"):
+        raise ImportError(
+            "SQLAlchemy is required for persistent storage. Install it via 'pip install SQLAlchemy'."
+        )

--- a/creative_search/pipeline.py
+++ b/creative_search/pipeline.py
@@ -1,0 +1,79 @@
+"""Orchestrates ingestion, conversion, and indexing."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Optional, Sequence, Set
+
+from . import ingestion, storage
+
+
+def run_pipeline(
+    server_dirs: Sequence[str | Path],
+    *,
+    extensions: Optional[Set[str]] = None,
+    ding_token: Optional[str] = None,
+    ding_channel: Optional[str] = None,
+    database_url: Optional[str] = None,
+) -> None:
+    """Run the end-to-end ingestion workflow."""
+
+    if not server_dirs:
+        raise ValueError("At least one server directory must be provided")
+
+    downloaded: Dict[str, str] = {}
+    primary_dir = Path(server_dirs[0]).expanduser()
+    if ding_token and ding_channel:
+        downloaded = ingestion.download_from_dingtalk(
+            ding_token,
+            ding_channel,
+            dest_dir=primary_dir,
+        )
+
+    file_paths = list(ingestion.list_files(server_dirs, extensions=extensions))
+    markdown_map = ingestion.ingest_and_convert(file_paths)
+
+    session_factory = None
+    if database_url is not None:
+        session_factory = storage.get_session_factory(database_url)
+
+    storage.add_documents_to_index(
+        markdown_map,
+        file_url_map=downloaded,
+        session_factory=session_factory,
+    )
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the Creative Search ingestion pipeline")
+    parser.add_argument(
+        "--dirs",
+        nargs="+",
+        required=True,
+        help="One or more directories that contain creative assets",
+    )
+    parser.add_argument(
+        "--extensions",
+        nargs="*",
+        help="Optional set of file extensions to include (e.g. pdf pptx docx)",
+    )
+    parser.add_argument("--ding-token", help="DingTalk API token", dest="ding_token")
+    parser.add_argument("--ding-channel", help="DingTalk channel identifier", dest="ding_channel")
+    parser.add_argument("--database-url", help="SQLAlchemy database URL", dest="database_url")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = build_argument_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    run_pipeline(
+        args.dirs,
+        extensions=set(args.extensions) if args.extensions else None,
+        ding_token=args.ding_token,
+        ding_channel=args.ding_channel,
+        database_url=args.database_url,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/creative_search/storage.py
+++ b/creative_search/storage.py
@@ -1,0 +1,260 @@
+"""Vector index management and persistence helpers."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from .embedding import generate_embedding, get_backend
+from .extraction import extract_entities
+from .models import (
+    DocumentMetadata,
+    SQLALCHEMY_AVAILABLE,
+    create_session_factory,
+)
+
+try:  # pragma: no cover - optional dependency
+    import faiss
+
+    FAISS_AVAILABLE = True
+except Exception:  # pragma: no cover - degrade gracefully
+    faiss = None  # type: ignore
+    FAISS_AVAILABLE = False
+
+
+class _NumpyFlatIndex:
+    """Minimal FAISS-like index for environments without the real library."""
+
+    def __init__(self, dimension: int) -> None:
+        self.dimension = dimension
+        self._vectors = np.zeros((0, dimension), dtype=np.float32)
+
+    @property
+    def ntotal(self) -> int:
+        return int(self._vectors.shape[0])
+
+    def add(self, vectors: np.ndarray) -> None:
+        arr = np.asarray(vectors, dtype=np.float32)
+        if arr.ndim == 1:
+            arr = arr.reshape(1, -1)
+        self._vectors = np.vstack([self._vectors, arr])
+
+    def search(self, query: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray]:
+        query_arr = np.asarray(query, dtype=np.float32)
+        if query_arr.ndim == 1:
+            query_arr = query_arr.reshape(1, -1)
+        if self.ntotal == 0:
+            distances = np.full((query_arr.shape[0], k), np.inf, dtype=np.float32)
+            indices = -np.ones((query_arr.shape[0], k), dtype=np.int64)
+            return distances, indices
+
+        dists = np.linalg.norm(self._vectors[None, :, :] - query_arr[:, None, :], axis=2)
+        k_eff = min(k, self.ntotal)
+        order = np.argsort(dists, axis=1)[:, :k_eff]
+        distances = np.take_along_axis(dists, order, axis=1)
+
+        if k_eff == k:
+            return distances.astype(np.float32), order.astype(np.int64)
+
+        padded_dist = np.full((query_arr.shape[0], k), np.inf, dtype=np.float32)
+        padded_idx = -np.ones((query_arr.shape[0], k), dtype=np.int64)
+        padded_dist[:, :k_eff] = distances
+        padded_idx[:, :k_eff] = order
+        return padded_dist, padded_idx
+
+
+class VectorIndex:
+    """Abstraction that hides whether FAISS is available."""
+
+    def __init__(self, dimension: int) -> None:
+        if FAISS_AVAILABLE:  # pragma: no cover - requires faiss runtime
+            self._index = faiss.IndexFlatL2(dimension)
+        else:
+            self._index = _NumpyFlatIndex(dimension)
+
+    @property
+    def ntotal(self) -> int:
+        if FAISS_AVAILABLE:  # pragma: no branch - tiny helper
+            return int(self._index.ntotal)
+        return int(self._index.ntotal)
+
+    def add(self, vectors: np.ndarray) -> None:
+        if FAISS_AVAILABLE:
+            self._index.add(np.asarray(vectors, dtype=np.float32))
+        else:
+            self._index.add(vectors)
+
+    def search(self, query: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray]:
+        if FAISS_AVAILABLE:
+            return self._index.search(np.asarray(query, dtype=np.float32), k)
+        return self._index.search(query, k)
+
+
+_INDEX: VectorIndex | None = None
+_SESSION_FACTORY = None
+_IN_MEMORY_METADATA: Dict[int, DocumentMetadata] = {}
+
+
+def get_index() -> VectorIndex:
+    global _INDEX
+    if _INDEX is None:
+        dimension = get_backend().dimension
+        _INDEX = VectorIndex(dimension)
+    return _INDEX
+
+
+def get_session_factory(database_url: Optional[str] = None):
+    global _SESSION_FACTORY
+    if _SESSION_FACTORY is None:
+        if not SQLALCHEMY_AVAILABLE:
+            raise ImportError(
+                "SQLAlchemy is required for persistence. Install it or run in memory only."
+            )
+        _SESSION_FACTORY = create_session_factory(database_url or "sqlite:///metadata.db")
+    return _SESSION_FACTORY
+
+
+def reset_state() -> None:
+    """Reset globals – handy for unit tests."""
+
+    global _INDEX, _SESSION_FACTORY, _IN_MEMORY_METADATA
+    _INDEX = None
+    _SESSION_FACTORY = None
+    _IN_MEMORY_METADATA = {}
+
+
+def add_documents_to_index(
+    markdown_map: Dict[str, str],
+    *,
+    file_url_map: Optional[Dict[str, str]] = None,
+    session_factory=None,
+) -> None:
+    """Extract metadata for ``markdown_map`` and add them to the vector index."""
+
+    index = get_index()
+    file_url_map = file_url_map or {}
+
+    if SQLALCHEMY_AVAILABLE:
+        session_factory = session_factory or get_session_factory()
+        session = session_factory()
+        try:
+            for path, markdown in markdown_map.items():
+                metadata = extract_entities(markdown)
+                record = (
+                    session.query(DocumentMetadata)
+                    .filter_by(file_path=path)
+                    .one_or_none()
+                )
+
+                if record is None:
+                    embedding = generate_embedding(markdown)
+                    vector = np.asarray([embedding], dtype=np.float32)
+                    embedding_index = index.ntotal
+                    index.add(vector)
+                    record = DocumentMetadata(
+                        file_path=path,
+                        file_url=file_url_map.get(path),
+                        concepts=metadata.concepts,
+                        colors=metadata.colors,
+                        materials=metadata.materials,
+                        prices=metadata.prices,
+                        product_types=metadata.product_types,
+                        clients=metadata.clients,
+                        product_lines=metadata.product_lines,
+                        proper_nouns=metadata.proper_nouns,
+                        embedding_index=embedding_index,
+                    )
+                    session.add(record)
+                else:
+                    record.file_url = file_url_map.get(path)
+                    record.concepts = metadata.concepts
+                    record.colors = metadata.colors
+                    record.materials = metadata.materials
+                    record.prices = metadata.prices
+                    record.product_types = metadata.product_types
+                    record.clients = metadata.clients
+                    record.product_lines = metadata.product_lines
+                    record.proper_nouns = metadata.proper_nouns
+            session.commit()
+        finally:
+            session.close()
+    else:  # fallback: store metadata in memory only
+        for path, markdown in markdown_map.items():
+            metadata = extract_entities(markdown)
+            existing_index = next(
+                (idx for idx, meta in _IN_MEMORY_METADATA.items() if meta.file_path == path),
+                None,
+            )
+            if existing_index is None:
+                embedding = generate_embedding(markdown)
+                vector = np.asarray([embedding], dtype=np.float32)
+                embedding_index = index.ntotal
+                index.add(vector)
+                _IN_MEMORY_METADATA[embedding_index] = DocumentMetadata(
+                    file_path=path,
+                    file_url=file_url_map.get(path),
+                    concepts=metadata.concepts,
+                    colors=metadata.colors,
+                    materials=metadata.materials,
+                    prices=metadata.prices,
+                    product_types=metadata.product_types,
+                    clients=metadata.clients,
+                    product_lines=metadata.product_lines,
+                    proper_nouns=metadata.proper_nouns,
+                    embedding_index=embedding_index,
+                )
+            else:
+                record = _IN_MEMORY_METADATA[existing_index]
+                record.file_url = file_url_map.get(path)
+                record.concepts = metadata.concepts
+                record.colors = metadata.colors
+                record.materials = metadata.materials
+                record.prices = metadata.prices
+                record.product_types = metadata.product_types
+                record.clients = metadata.clients
+                record.product_lines = metadata.product_lines
+                record.proper_nouns = metadata.proper_nouns
+
+
+def search_similar(query: str, k: int = 5) -> List[dict]:
+    """Return metadata records ordered by vector similarity."""
+
+    index = get_index()
+    if index.ntotal == 0:
+        return []
+
+    query_emb = generate_embedding(query)
+    distances, indices = index.search(np.asarray([query_emb]), k)
+
+    results: List[dict] = []
+    if SQLALCHEMY_AVAILABLE:
+        session = get_session_factory()()
+        try:
+            for distance, idx in zip(distances[0], indices[0]):
+                if idx < 0:
+                    continue
+                record = (
+                    session.query(DocumentMetadata)
+                    .filter_by(embedding_index=int(idx))
+                    .one_or_none()
+                )
+                if record is None:
+                    continue
+                results.append({
+                    "score": float(distance),
+                    "metadata": record.as_dict(),
+                })
+        finally:
+            session.close()
+    else:
+        for distance, idx in zip(distances[0], indices[0]):
+            if idx < 0:
+                continue
+            record = _IN_MEMORY_METADATA.get(int(idx))
+            if record is None:
+                continue
+            results.append({
+                "score": float(distance),
+                "metadata": record.as_dict(),
+            })
+    return results


### PR DESCRIPTION
## Summary
- add a `creative_search` package that covers ingestion, extraction, embedding, storage, and API layers with graceful fallbacks for optional dependencies
- provide a CLI pipeline runner and FastAPI app for running the ingestion workflow and serving search results
- expand the README with setup, dependency, and usage documentation for the new pipeline

## Testing
- python -m compileall creative_search

------
https://chatgpt.com/codex/tasks/task_e_68cc7fb3352c832d82d9045f86e9aa05